### PR TITLE
Update LinearRegression_scikit-learn.py

### DIFF
--- a/LinearRegression/LinearRegression_scikit-learn.py
+++ b/LinearRegression/LinearRegression_scikit-learn.py
@@ -14,7 +14,7 @@ def linearRegression():
     scaler = StandardScaler()   
     scaler.fit(X)
     x_train = scaler.transform(X)
-    x_test = scaler.transform(np.array([1650,3]))
+    x_test = scaler.transform(np.array([[1650,3]]))
     
     # 线性模型拟合
     model = linear_model.LinearRegression()


### PR DESCRIPTION
changes for python3
scaler.transform()方法需要传入一个二维数组作为输入，而你传入的是一个一维数组